### PR TITLE
Feature - Use Dataplugin fullDescription in docs snippets

### DIFF
--- a/content/data-sources/tap-auth0.md
+++ b/content/data-sources/tap-auth0.md
@@ -13,3 +13,7 @@ nav_order: 1
 <img src="{{site.baseurl}}/assets/data_source_images/tap-auth0.png" width="125" alt="auth0">
 
 {% include snippets/api/markdown-descriptions/tap-auth0/dataplugin-description.md %}
+
+## Learn more
+
+[View this plugin on the Meltano Hub](https://hub.meltano.com/extractors/tap-auth0/)

--- a/content/data-sources/tap-github.md
+++ b/content/data-sources/tap-github.md
@@ -13,3 +13,7 @@ nav_order: 2
 <img src="{{site.baseurl}}/assets/data_source_images/tap-github.png" width="125" alt="github">
 
 {% include snippets/api/markdown-descriptions/tap-github/dataplugin-description.md %}
+
+## Learn more
+
+[View this plugin on the Meltano Hub](https://hub.meltano.com/extractors/tap-github/)

--- a/content/data-sources/tap-google-sheets.md
+++ b/content/data-sources/tap-google-sheets.md
@@ -13,3 +13,7 @@ nav_order: 4
 <img src="{{site.baseurl}}/assets/data_source_images/tap-google-sheets.png" width="125" alt="google-sheets">
 
 {% include snippets/api/markdown-descriptions/tap-google-sheets/dataplugin-description.md %}
+
+## Learn more
+
+[View this plugin on the Meltano Hub](https://hub.meltano.com/extractors/tap-google-sheets/)

--- a/content/data-sources/tap-googleads.md
+++ b/content/data-sources/tap-googleads.md
@@ -13,3 +13,7 @@ nav_order: 5
 ![google-ads-logo]({{site.baseurl}}/assets/data_source_images/tap-googleads.svg)
 
 {% include snippets/api/markdown-descriptions/tap-googleads/dataplugin-description.md %}
+
+## Learn more
+
+[View this plugin on the Meltano Hub](https://hub.meltano.com/extractors/tap-googleads/)

--- a/content/data-sources/tap-govuk-weekly-road-fuel-prices.md
+++ b/content/data-sources/tap-govuk-weekly-road-fuel-prices.md
@@ -13,3 +13,7 @@ nav_order: 2
 <img src="{{site.baseurl}}/assets/data_source_images/national-statistics.png" width="125" alt="github">
 
 {% include snippets/api/markdown-descriptions/tap-govuk-weekly-road-fuel-prices/dataplugin-description.md %}
+
+## Learn more
+
+[Weekly road fuel prices](https://www.gov.uk/government/statistics/weekly-road-fuel-prices)

--- a/content/data-sources/tap-meltano.md
+++ b/content/data-sources/tap-meltano.md
@@ -13,3 +13,7 @@ nav_order: 6
 <img src="{{site.baseurl}}/assets/data_source_images/tap-meltano.png" width="125" alt="meltano">
 
 {% include snippets/api/markdown-descriptions/tap-meltano/dataplugin-description.md %}
+
+## Learn more
+
+[View this plugin on the Meltano Hub](https://hub.meltano.com/extractors/tap-meltano/)

--- a/content/data-sources/tap-shopify.md
+++ b/content/data-sources/tap-shopify.md
@@ -13,3 +13,7 @@ nav_order: 7
 <img src="{{site.baseurl}}/assets/data_source_images/tap-shopify.png" width="125" alt="shopify">
 
 {% include snippets/api/markdown-descriptions/tap-shopify/dataplugin-description.md %}
+
+## Learn more
+
+[View this plugin on the Meltano Hub](https://hub.meltano.com/extractors/tap-shopify)

--- a/content/data-sources/tap-solarvista.md
+++ b/content/data-sources/tap-solarvista.md
@@ -13,3 +13,7 @@ nav_order: 8
 ![solarvista-logo]({{site.baseurl}}/assets/data_source_images/tap-solarvista.png)
 
 {% include snippets/api/markdown-descriptions/tap-solarvista/dataplugin-description.md %}
+
+## Learn more
+
+[View this plugin on the Meltano Hub](https://hub.meltano.com/extractors/tap-solarvista/)

--- a/content/data-sources/tap-spotify.md
+++ b/content/data-sources/tap-spotify.md
@@ -13,3 +13,7 @@ nav_order: 9
 <img src="{{site.baseurl}}/assets/data_source_images/tap-spotify.png" width="125" alt="spotify">
 
 {% include snippets/api/markdown-descriptions/tap-spotify/dataplugin-description.md %}
+
+## Learn more
+
+[View this plugin on the Meltano Hub](https://hub.meltano.com/extractors/tap-spotify)

--- a/content/data-sources/tap-trello.md
+++ b/content/data-sources/tap-trello.md
@@ -13,3 +13,7 @@ nav_order: 10
 <img src="{{site.baseurl}}/assets/data_source_images/tap-trello.png" width="125" alt="trello">
 
 {% include snippets/api/markdown-descriptions/tap-trello/dataplugin-description.md %}
+
+## Learn more
+
+[View this plugin on the Meltano Hub](https://hub.meltano.com/extractors/tap-trello--matatika/)


### PR DESCRIPTION
- Updated each of the data source top level pages to have a "hard coded" `Learn more` section with applicable links, as we now do not have a `Learn more` section in the Dataplugin description snippet.